### PR TITLE
[16.0][IMP] connector_elasticsearch: Implements reindex via rolling update

### DIFF
--- a/connector_elasticsearch/models/se_backend.py
+++ b/connector_elasticsearch/models/se_backend.py
@@ -19,7 +19,7 @@ class SeBackend(models.Model):
     api_key_id = fields.Char(help="Elasticsearch Api Key ID", string="Api Key ID")
     api_key = fields.Char(help="Elasticsearch Api Key")
 
-    def get_adapter_class(self):
+    def _get_adapter_class(self):
         if self.backend_type == "elasticsearch":
             return ElasticSearchAdapter
         else:

--- a/connector_elasticsearch/tests/cassettes/TestConnectorElasticsearch.test_index_adapter.yaml
+++ b/connector_elasticsearch/tests/cassettes/TestConnectorElasticsearch.test_index_adapter.yaml
@@ -11,17 +11,17 @@ interactions:
       content-type:
       - application/json
       user-agent:
-      - elasticsearch-py/7.13.4 (Python 3.9.16)
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
       x-elastic-client-meta:
-      - es=7.13.4,py=3.9.16,t=7.13.4,rq=2.28.1,h=bp
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2,h=bp
     method: POST
     uri: http://elastic:9200/_bulk
   response:
     body:
-      string: '{"took":8,"errors":false,"items":[{"index":{"_index":"demo_elasticsearch_backend_contact_en_us","_type":"_doc","_id":"foo","_version":2,"result":"updated","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":3,"_primary_term":1,"status":200}}]}'
+      string: '{"took":12,"errors":false,"items":[{"index":{"_index":"demo_elasticsearch_backend_contact_en_us-2","_type":"_doc","_id":"foo","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":5,"_primary_term":1,"status":201}}]}'
     headers:
       content-length:
-      - '249'
+      - '252'
       content-type:
       - application/json; charset=UTF-8
     status:

--- a/connector_elasticsearch/tests/cassettes/TestConnectorElasticsearch.test_index_adapter_delete.yaml
+++ b/connector_elasticsearch/tests/cassettes/TestConnectorElasticsearch.test_index_adapter_delete.yaml
@@ -2,16 +2,108 @@ interactions:
 - request:
     body: null
     headers:
+      content-type:
+      - application/json
+      user-agent:
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
+      x-elastic-client-meta:
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2
+    method: GET
+    uri: http://elastic:9200/_alias/demo_elasticsearch_backend_contact_en_us
+  response:
+    body:
+      string: '{"demo_elasticsearch_backend_contact_en_us-2":{"aliases":{"demo_elasticsearch_backend_contact_en_us":{}}}}'
+    headers:
+      content-length:
+      - '106'
+      content-type:
+      - application/json; charset=UTF-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
       Content-Length:
       - '0'
       content-type:
       - application/json
       user-agent:
-      - elasticsearch-py/7.13.4 (Python 3.9.16)
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
       x-elastic-client-meta:
-      - es=7.13.4,py=3.9.16,t=7.13.4,rq=2.28.1
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2
     method: DELETE
+    uri: http://elastic:9200/demo_elasticsearch_backend_contact_en_us-2
+  response:
+    body:
+      string: '{"acknowledged":true}'
+    headers:
+      content-length:
+      - '21'
+      content-type:
+      - application/json; charset=UTF-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      content-type:
+      - application/json
+      user-agent:
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
+      x-elastic-client-meta:
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2
+    method: HEAD
     uri: http://elastic:9200/demo_elasticsearch_backend_contact_en_us
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '569'
+      content-type:
+      - application/json; charset=UTF-8
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: '{}'
+    headers:
+      Content-Length:
+      - '2'
+      content-type:
+      - application/json
+      user-agent:
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
+      x-elastic-client-meta:
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2
+    method: PUT
+    uri: http://elastic:9200/demo_elasticsearch_backend_contact_en_us-1
+  response:
+    body:
+      string: '{"acknowledged":true,"shards_acknowledged":true,"index":"demo_elasticsearch_backend_contact_en_us-1"}'
+    headers:
+      content-length:
+      - '101'
+      content-type:
+      - application/json; charset=UTF-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Content-Length:
+      - '0'
+      content-type:
+      - application/json
+      user-agent:
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
+      x-elastic-client-meta:
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2
+    method: PUT
+    uri: http://elastic:9200/demo_elasticsearch_backend_contact_en_us-1/_alias/demo_elasticsearch_backend_contact_en_us
   response:
     body:
       string: '{"acknowledged":true}'
@@ -43,17 +135,17 @@ interactions:
       content-type:
       - application/json
       user-agent:
-      - elasticsearch-py/7.13.4 (Python 3.9.16)
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
       x-elastic-client-meta:
-      - es=7.13.4,py=3.9.16,t=7.13.4,rq=2.28.1,h=bp
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2,h=bp
     method: POST
     uri: http://elastic:9200/_bulk
   response:
     body:
-      string: '{"took":231,"errors":false,"items":[{"index":{"_index":"demo_elasticsearch_backend_contact_en_us","_type":"_doc","_id":"foo","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"index":{"_index":"demo_elasticsearch_backend_contact_en_us","_type":"_doc","_id":"foo2","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":1,"_primary_term":1,"status":201}},{"index":{"_index":"demo_elasticsearch_backend_contact_en_us","_type":"_doc","_id":"foo3","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":2,"_primary_term":1,"status":201}}]}'
+      string: '{"took":42,"errors":false,"items":[{"index":{"_index":"demo_elasticsearch_backend_contact_en_us-1","_type":"_doc","_id":"foo","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"index":{"_index":"demo_elasticsearch_backend_contact_en_us-1","_type":"_doc","_id":"foo2","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":1,"_primary_term":1,"status":201}},{"index":{"_index":"demo_elasticsearch_backend_contact_en_us-1","_type":"_doc","_id":"foo3","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":2,"_primary_term":1,"status":201}}]}'
     headers:
       content-length:
-      - '681'
+      - '686'
       content-type:
       - application/json; charset=UTF-8
     status:
@@ -71,17 +163,17 @@ interactions:
       content-type:
       - application/json
       user-agent:
-      - elasticsearch-py/7.13.4 (Python 3.9.16)
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
       x-elastic-client-meta:
-      - es=7.13.4,py=3.9.16,t=7.13.4,rq=2.28.1,h=bp
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2,h=bp
     method: POST
     uri: http://elastic:9200/_bulk
   response:
     body:
-      string: '{"took":28,"errors":false,"items":[{"delete":{"_index":"demo_elasticsearch_backend_contact_en_us","_type":"_doc","_id":"foo","_version":2,"result":"deleted","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":3,"_primary_term":1,"status":200}},{"delete":{"_index":"demo_elasticsearch_backend_contact_en_us","_type":"_doc","_id":"foo3","_version":2,"result":"deleted","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":4,"_primary_term":1,"status":200}}]}'
+      string: '{"took":15,"errors":false,"items":[{"delete":{"_index":"demo_elasticsearch_backend_contact_en_us-1","_type":"_doc","_id":"foo","_version":2,"result":"deleted","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":3,"_primary_term":1,"status":200}},{"delete":{"_index":"demo_elasticsearch_backend_contact_en_us-1","_type":"_doc","_id":"foo3","_version":2,"result":"deleted","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":4,"_primary_term":1,"status":200}}]}'
     headers:
       content-length:
-      - '467'
+      - '471'
       content-type:
       - application/json; charset=UTF-8
     status:
@@ -95,9 +187,9 @@ interactions:
       content-type:
       - application/json
       user-agent:
-      - elasticsearch-py/7.13.4 (Python 3.9.16)
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
       x-elastic-client-meta:
-      - es=7.13.4,py=3.9.16,t=7.13.4,rq=2.28.1
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2
     method: POST
     uri: http://elastic:9200/demo_elasticsearch_backend_contact_en_us/_search?filter_path=hits.hits._source
   response:

--- a/connector_elasticsearch/tests/cassettes/TestConnectorElasticsearch.test_index_adapter_delete_nonexisting_documents.yaml
+++ b/connector_elasticsearch/tests/cassettes/TestConnectorElasticsearch.test_index_adapter_delete_nonexisting_documents.yaml
@@ -11,17 +11,17 @@ interactions:
       content-type:
       - application/json
       user-agent:
-      - elasticsearch-py/7.13.4 (Python 3.9.16)
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
       x-elastic-client-meta:
-      - es=7.13.4,py=3.9.16,t=7.13.4,rq=2.28.1,h=bp
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2,h=bp
     method: POST
     uri: http://elastic:9200/_bulk
   response:
     body:
-      string: '{"took":11,"errors":false,"items":[{"delete":{"_index":"demo_elasticsearch_backend_contact_en_us","_type":"_doc","_id":"donotexist","_version":1,"result":"not_found","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":5,"_primary_term":1,"status":404}},{"delete":{"_index":"demo_elasticsearch_backend_contact_en_us","_type":"_doc","_id":"donotexisteither","_version":1,"result":"not_found","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":6,"_primary_term":1,"status":404}}]}'
+      string: '{"took":20,"errors":false,"items":[{"delete":{"_index":"demo_elasticsearch_backend_contact_en_us-1","_type":"_doc","_id":"donotexist","_version":1,"result":"not_found","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":5,"_primary_term":1,"status":404}},{"delete":{"_index":"demo_elasticsearch_backend_contact_en_us-1","_type":"_doc","_id":"donotexisteither","_version":1,"result":"not_found","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":6,"_primary_term":1,"status":404}}]}'
     headers:
       content-length:
-      - '490'
+      - '494'
       content-type:
       - application/json; charset=UTF-8
     status:

--- a/connector_elasticsearch/tests/cassettes/TestConnectorElasticsearch.test_index_adapter_iter.yaml
+++ b/connector_elasticsearch/tests/cassettes/TestConnectorElasticsearch.test_index_adapter_iter.yaml
@@ -2,16 +2,108 @@ interactions:
 - request:
     body: null
     headers:
+      content-type:
+      - application/json
+      user-agent:
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
+      x-elastic-client-meta:
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2
+    method: GET
+    uri: http://elastic:9200/_alias/demo_elasticsearch_backend_contact_en_us
+  response:
+    body:
+      string: '{"demo_elasticsearch_backend_contact_en_us-1":{"aliases":{"demo_elasticsearch_backend_contact_en_us":{}}}}'
+    headers:
+      content-length:
+      - '106'
+      content-type:
+      - application/json; charset=UTF-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
       Content-Length:
       - '0'
       content-type:
       - application/json
       user-agent:
-      - elasticsearch-py/7.13.4 (Python 3.9.16)
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
       x-elastic-client-meta:
-      - es=7.13.4,py=3.9.16,t=7.13.4,rq=2.28.1
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2
     method: DELETE
+    uri: http://elastic:9200/demo_elasticsearch_backend_contact_en_us-1
+  response:
+    body:
+      string: '{"acknowledged":true}'
+    headers:
+      content-length:
+      - '21'
+      content-type:
+      - application/json; charset=UTF-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      content-type:
+      - application/json
+      user-agent:
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
+      x-elastic-client-meta:
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2
+    method: HEAD
     uri: http://elastic:9200/demo_elasticsearch_backend_contact_en_us
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '569'
+      content-type:
+      - application/json; charset=UTF-8
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: '{}'
+    headers:
+      Content-Length:
+      - '2'
+      content-type:
+      - application/json
+      user-agent:
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
+      x-elastic-client-meta:
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2
+    method: PUT
+    uri: http://elastic:9200/demo_elasticsearch_backend_contact_en_us-1
+  response:
+    body:
+      string: '{"acknowledged":true,"shards_acknowledged":true,"index":"demo_elasticsearch_backend_contact_en_us-1"}'
+    headers:
+      content-length:
+      - '101'
+      content-type:
+      - application/json; charset=UTF-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Content-Length:
+      - '0'
+      content-type:
+      - application/json
+      user-agent:
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
+      x-elastic-client-meta:
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2
+    method: PUT
+    uri: http://elastic:9200/demo_elasticsearch_backend_contact_en_us-1/_alias/demo_elasticsearch_backend_contact_en_us
   response:
     body:
       string: '{"acknowledged":true}'
@@ -43,17 +135,17 @@ interactions:
       content-type:
       - application/json
       user-agent:
-      - elasticsearch-py/7.13.4 (Python 3.9.16)
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
       x-elastic-client-meta:
-      - es=7.13.4,py=3.9.16,t=7.13.4,rq=2.28.1,h=bp
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2,h=bp
     method: POST
     uri: http://elastic:9200/_bulk
   response:
     body:
-      string: '{"took":140,"errors":false,"items":[{"index":{"_index":"demo_elasticsearch_backend_contact_en_us","_type":"_doc","_id":"foo","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"index":{"_index":"demo_elasticsearch_backend_contact_en_us","_type":"_doc","_id":"foo2","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":1,"_primary_term":1,"status":201}},{"index":{"_index":"demo_elasticsearch_backend_contact_en_us","_type":"_doc","_id":"foo3","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":2,"_primary_term":1,"status":201}}]}'
+      string: '{"took":23,"errors":false,"items":[{"index":{"_index":"demo_elasticsearch_backend_contact_en_us-1","_type":"_doc","_id":"foo","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"index":{"_index":"demo_elasticsearch_backend_contact_en_us-1","_type":"_doc","_id":"foo2","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":1,"_primary_term":1,"status":201}},{"index":{"_index":"demo_elasticsearch_backend_contact_en_us-1","_type":"_doc","_id":"foo3","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":2,"_primary_term":1,"status":201}}]}'
     headers:
       content-length:
-      - '681'
+      - '686'
       content-type:
       - application/json; charset=UTF-8
     status:
@@ -67,9 +159,9 @@ interactions:
       content-type:
       - application/json
       user-agent:
-      - elasticsearch-py/7.13.4 (Python 3.9.16)
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
       x-elastic-client-meta:
-      - es=7.13.4,py=3.9.16,t=7.13.4,rq=2.28.1
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2
     method: POST
     uri: http://elastic:9200/demo_elasticsearch_backend_contact_en_us/_search?filter_path=hits.hits._source
   response:

--- a/connector_elasticsearch/tests/cassettes/TestConnectorElasticsearch.test_index_adapter_reindex.yaml
+++ b/connector_elasticsearch/tests/cassettes/TestConnectorElasticsearch.test_index_adapter_reindex.yaml
@@ -1,0 +1,363 @@
+interactions:
+- request:
+    body: null
+    headers:
+      content-type:
+      - application/json
+      user-agent:
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
+      x-elastic-client-meta:
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2
+    method: GET
+    uri: http://elastic:9200/_alias/demo_elasticsearch_backend_contact_en_us
+  response:
+    body:
+      string: '{"demo_elasticsearch_backend_contact_en_us-1":{"aliases":{"demo_elasticsearch_backend_contact_en_us":{}}}}'
+    headers:
+      content-length:
+      - '106'
+      content-type:
+      - application/json; charset=UTF-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Content-Length:
+      - '0'
+      content-type:
+      - application/json
+      user-agent:
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
+      x-elastic-client-meta:
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2
+    method: DELETE
+    uri: http://elastic:9200/demo_elasticsearch_backend_contact_en_us-1
+  response:
+    body:
+      string: '{"acknowledged":true}'
+    headers:
+      content-length:
+      - '21'
+      content-type:
+      - application/json; charset=UTF-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      content-type:
+      - application/json
+      user-agent:
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
+      x-elastic-client-meta:
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2
+    method: HEAD
+    uri: http://elastic:9200/demo_elasticsearch_backend_contact_en_us
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '569'
+      content-type:
+      - application/json; charset=UTF-8
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: '{}'
+    headers:
+      Content-Length:
+      - '2'
+      content-type:
+      - application/json
+      user-agent:
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
+      x-elastic-client-meta:
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2
+    method: PUT
+    uri: http://elastic:9200/demo_elasticsearch_backend_contact_en_us-1
+  response:
+    body:
+      string: '{"acknowledged":true,"shards_acknowledged":true,"index":"demo_elasticsearch_backend_contact_en_us-1"}'
+    headers:
+      content-length:
+      - '101'
+      content-type:
+      - application/json; charset=UTF-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Content-Length:
+      - '0'
+      content-type:
+      - application/json
+      user-agent:
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
+      x-elastic-client-meta:
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2
+    method: PUT
+    uri: http://elastic:9200/demo_elasticsearch_backend_contact_en_us-1/_alias/demo_elasticsearch_backend_contact_en_us
+  response:
+    body:
+      string: '{"acknowledged":true}'
+    headers:
+      content-length:
+      - '21'
+      content-type:
+      - application/json; charset=UTF-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"index":{"_id":"foo","_index":"demo_elasticsearch_backend_contact_en_us"}}
+
+      {"id":"foo"}
+
+      {"index":{"_id":"foo2","_index":"demo_elasticsearch_backend_contact_en_us"}}
+
+      {"id":"foo2"}
+
+      {"index":{"_id":"foo3","_index":"demo_elasticsearch_backend_contact_en_us"}}
+
+      {"id":"foo3"}
+
+      '
+    headers:
+      Content-Length:
+      - '271'
+      content-type:
+      - application/json
+      user-agent:
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
+      x-elastic-client-meta:
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2,h=bp
+    method: POST
+    uri: http://elastic:9200/_bulk
+  response:
+    body:
+      string: '{"took":24,"errors":false,"items":[{"index":{"_index":"demo_elasticsearch_backend_contact_en_us-1","_type":"_doc","_id":"foo","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"index":{"_index":"demo_elasticsearch_backend_contact_en_us-1","_type":"_doc","_id":"foo2","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":1,"_primary_term":1,"status":201}},{"index":{"_index":"demo_elasticsearch_backend_contact_en_us-1","_type":"_doc","_id":"foo3","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":2,"_primary_term":1,"status":201}}]}'
+    headers:
+      content-length:
+      - '686'
+      content-type:
+      - application/json; charset=UTF-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      content-type:
+      - application/json
+      user-agent:
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
+      x-elastic-client-meta:
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2
+    method: GET
+    uri: http://elastic:9200/_alias/demo_elasticsearch_backend_contact_en_us
+  response:
+    body:
+      string: '{"demo_elasticsearch_backend_contact_en_us-1":{"aliases":{"demo_elasticsearch_backend_contact_en_us":{}}}}'
+    headers:
+      content-length:
+      - '106'
+      content-type:
+      - application/json; charset=UTF-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      content-type:
+      - application/json
+      user-agent:
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
+      x-elastic-client-meta:
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2
+    method: GET
+    uri: http://elastic:9200/_alias/demo_elasticsearch_backend_contact_en_us
+  response:
+    body:
+      string: '{"demo_elasticsearch_backend_contact_en_us-1":{"aliases":{"demo_elasticsearch_backend_contact_en_us":{}}}}'
+    headers:
+      content-length:
+      - '106'
+      content-type:
+      - application/json; charset=UTF-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Content-Length:
+      - '2'
+      content-type:
+      - application/json
+      user-agent:
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
+      x-elastic-client-meta:
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2
+    method: PUT
+    uri: http://elastic:9200/demo_elasticsearch_backend_contact_en_us-2
+  response:
+    body:
+      string: '{"acknowledged":true,"shards_acknowledged":true,"index":"demo_elasticsearch_backend_contact_en_us-2"}'
+    headers:
+      content-length:
+      - '101'
+      content-type:
+      - application/json; charset=UTF-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"source":{"index":"demo_elasticsearch_backend_contact_en_us"},"dest":{"index":"demo_elasticsearch_backend_contact_en_us-2"}}'
+    headers:
+      Content-Length:
+      - '125'
+      content-type:
+      - application/json
+      user-agent:
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
+      x-elastic-client-meta:
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2
+    method: POST
+    uri: http://elastic:9200/_reindex?wait_for_completion=false
+  response:
+    body:
+      string: '{"task":"Ch4zlGppTF-9rtPxsPpYeQ:1982"}'
+    headers:
+      content-length:
+      - '38'
+      content-type:
+      - application/json; charset=UTF-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      content-type:
+      - application/json
+      user-agent:
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
+      x-elastic-client-meta:
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2
+    method: GET
+    uri: http://elastic:9200/_tasks/Ch4zlGppTF-9rtPxsPpYeQ%3A1982?wait_for_completion=false
+  response:
+    body:
+      string: '{"completed":true,"task":{"node":"Ch4zlGppTF-9rtPxsPpYeQ","id":1982,"type":"transport","action":"indices:data/write/reindex","status":{"total":3,"updated":0,"created":3,"deleted":0,"batches":1,"version_conflicts":0,"noops":0,"retries":{"bulk":0,"search":0},"throttled_millis":0,"requests_per_second":-1.0,"throttled_until_millis":0},"description":"reindex
+        from [demo_elasticsearch_backend_contact_en_us] to [demo_elasticsearch_backend_contact_en_us-2][_doc]","start_time_in_millis":1680783039576,"running_time_in_nanos":27227295,"cancellable":true,"headers":{}},"response":{"took":27,"timed_out":false,"total":3,"updated":0,"created":3,"deleted":0,"batches":1,"version_conflicts":0,"noops":0,"retries":{"bulk":0,"search":0},"throttled":"0s","throttled_millis":0,"requests_per_second":-1.0,"throttled_until":"0s","throttled_until_millis":0,"failures":[]}}'
+    headers:
+      content-length:
+      - '854'
+      content-type:
+      - application/json; charset=UTF-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"actions":[{"remove":{"index":"demo_elasticsearch_backend_contact_en_us-1","alias":"demo_elasticsearch_backend_contact_en_us"}},{"add":{"index":"demo_elasticsearch_backend_contact_en_us-2","alias":"demo_elasticsearch_backend_contact_en_us"}}]}'
+    headers:
+      Content-Length:
+      - '244'
+      content-type:
+      - application/json
+      user-agent:
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
+      x-elastic-client-meta:
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2
+    method: POST
+    uri: http://elastic:9200/_aliases
+  response:
+    body:
+      string: '{"acknowledged":true}'
+    headers:
+      content-length:
+      - '21'
+      content-type:
+      - application/json; charset=UTF-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Content-Length:
+      - '0'
+      content-type:
+      - application/json
+      user-agent:
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
+      x-elastic-client-meta:
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2
+    method: DELETE
+    uri: http://elastic:9200/demo_elasticsearch_backend_contact_en_us-1
+  response:
+    body:
+      string: '{"acknowledged":true}'
+    headers:
+      content-length:
+      - '21'
+      content-type:
+      - application/json; charset=UTF-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Content-Length:
+      - '0'
+      content-type:
+      - application/json
+      user-agent:
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
+      x-elastic-client-meta:
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2
+    method: POST
+    uri: http://elastic:9200/demo_elasticsearch_backend_contact_en_us/_search?filter_path=hits.hits._source
+  response:
+    body:
+      string: '{"hits":{"hits":[{"_source":{"id":"foo"}},{"_source":{"id":"foo2"}},{"_source":{"id":"foo3"}}]}}'
+    headers:
+      content-length:
+      - '96'
+      content-type:
+      - application/json; charset=UTF-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      content-type:
+      - application/json
+      user-agent:
+      - elasticsearch-py/7.13.4 (Python 3.10.6)
+      x-elastic-client-meta:
+      - es=7.13.4,py=3.10.6,t=7.13.4,rq=2.28.2
+    method: GET
+    uri: http://elastic:9200/_alias/demo_elasticsearch_backend_contact_en_us
+  response:
+    body:
+      string: '{"demo_elasticsearch_backend_contact_en_us-2":{"aliases":{"demo_elasticsearch_backend_contact_en_us":{}}}}'
+    headers:
+      content-length:
+      - '106'
+      content-type:
+      - application/json; charset=UTF-8
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/connector_elasticsearch/tools/adapter.py
+++ b/connector_elasticsearch/tools/adapter.py
@@ -2,6 +2,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import logging
+import time
+from typing import Any, Iterator
 
 from odoo import _
 from odoo.exceptions import UserError
@@ -25,6 +27,10 @@ def _is_delete_nonexistent_documents(elastic_exception):
 
 
 class ElasticSearchAdapter(SearchEngineAdapter):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__es_client = None
+
     @property
     def _index_name(self):
         return self.index_record.name.lower()
@@ -32,6 +38,16 @@ class ElasticSearchAdapter(SearchEngineAdapter):
     @property
     def _es_connection_class(self):
         return elasticsearch.RequestsHttpConnection
+
+    @property
+    def _es_client(self):
+        if not self.__es_client:
+            self.__es_client = self._get_es_client()
+        return self.__es_client
+
+    @property
+    def _index_config(self):
+        return self.index_record.config_id.body
 
     def _get_es_client(self):
         backend = self.backend_record
@@ -47,7 +63,7 @@ class ElasticSearchAdapter(SearchEngineAdapter):
         )
 
     def test_connection(self):
-        es = self._get_es_client()
+        es = self._es_client
         try:
             es.security.authenticate()
         except elasticsearch.NotFoundError as exc:
@@ -57,8 +73,8 @@ class ElasticSearchAdapter(SearchEngineAdapter):
         except Exception as exc:
             raise UserError(_("Unable to connect :") + "\n\n" + repr(exc)) from exc
 
-    def index(self, records):
-        es = self._get_es_client()
+    def index(self, records) -> None:
+        es = self._es_client
         records_for_bulk = [
             {
                 "_index": self._index_name,
@@ -69,10 +85,19 @@ class ElasticSearchAdapter(SearchEngineAdapter):
         ]
         res = elasticsearch.helpers.bulk(es, records_for_bulk)
         # checks if number of indexed object and object in records are equal
-        return len(records) - res[0] == 0
+        if not res[0] == len(records):
+            raise SystemError(
+                _(
+                    "Unable to index all records. (indexed: %(indexed)s, "
+                    "total: %(total)s)\n%(result)s",
+                    indexed=res[0],
+                    total=len(records),
+                    result=res,
+                )
+            )
 
-    def delete(self, binding_ids):
-        es = self._get_es_client()
+    def delete(self, binding_ids) -> None:
+        es = self._es_client
         records_for_bulk = []
         for binding_id in binding_ids:
             action = {
@@ -91,31 +116,126 @@ class ElasticSearchAdapter(SearchEngineAdapter):
             msg = "Trying to delete non-existent documents. Ignored: %s"
             _logger.info(msg, e)
 
-    def clear(self):
-        es = self._get_es_client()
-        res = es.indices.delete(index=self._index_name, ignore=[400, 404])
-        # recreate the index
-        self._get_es_client()
-        return res["acknowledged"]
+    def clear(self) -> None:
+        es = self._es_client
+        index_name = self._get_current_aliased_index_name() or self._index_name
+        res = es.indices.delete(index=index_name, ignore=[400, 404])
+        self.settings()
+        if not res["acknowledged"]:
+            raise SystemError(
+                _(
+                    "Unable to clear index %(index_name)s: %(result)",
+                    index_name=index_name,
+                    result=res,
+                )
+            )
 
-    def each(self):
-        es = self._get_es_client()
+    def each(self) -> Iterator[dict[str, Any]]:
+        es = self._es_client
         res = es.search(index=self._index_name, filter_path=["hits.hits._source"])
         if not res:
             # eg: empty index
-            return []
+            return
         hits = res["hits"]["hits"]
-        return [r["_source"] for r in hits]
+        for hit in hits:
+            yield hit["_source"]
 
-    def settings(self):
-        es = self._get_es_client()
-        index_name = self._index_name
-        if not es.indices.exists(index_name):
-            es.indices.create(index=index_name, body=self.work.index.config_id.body)
+    def settings(self) -> None:
+        es = self._es_client
+        if not es.indices.exists(self._index_name):
+            client = self._es_client
+            # To allow rolling updates, we work with index aliases
+            aliased_index_name = self._get_next_aliased_index_name()
+            client.indices.create(index=aliased_index_name, body=self._index_config)
+            client.indices.put_alias(index=aliased_index_name, name=self._index_name)
             msg = "Missing index %s created."
-            _logger.info(msg, index_name)
+            _logger.info(msg, self._index_name)
         # TODO: understand how to handle this only for dynamic indexes.
         # For non dynamic indexes you should delete the index and reindex.
         # if not created and force:
         #     es.indices.put_settings(self.work.index.config_id.body, index=index_name)
-        return True
+
+    def _get_current_aliased_index_name(self) -> str:
+        """Get the current aliased index name if any"""
+        current_aliased_index_name = None
+        alias = self._es_client.indices.get_alias(
+            name=self._index_name, ignore=[400, 404]
+        )
+        if "error" not in alias:
+            current_aliased_index_name = next(iter(alias))  # get the first key
+        return current_aliased_index_name
+
+    def _get_next_aliased_index_name(
+        self, aliased_index_name: str | None = None
+    ) -> str:
+        """Get the next aliased index name
+
+        The next aliased index name is based on the current aliased index name.
+        It's the current aliased index name incremented by 1.
+
+        :param aliased_index_name: the current aliased index name
+        :return: the next aliased index name
+        """
+        next_version = 1
+        if aliased_index_name:
+            next_version = int(aliased_index_name.split("-")[-1]) + 1
+        return "%s-%d" % (self._index_name, next_version)
+
+    def reindex(self) -> None:
+        """Reindex records according to the current config
+        This method is useful to allows a rolling update of index
+        configuration.
+        This process is based on the following steps:
+        1. create a new index with the current config
+        2. trigger a reindex into SE from the current index to the new one
+        3. Update the index alias to point to the new index
+        4. Drop the old index.
+        """
+        client = self._es_client
+        current_aliased_index_name = self._get_current_aliased_index_name()
+        next_aliased_index_name = self._get_next_aliased_index_name(
+            current_aliased_index_name
+        )
+        # create new idx
+        client.indices.create(index=next_aliased_index_name, body=self._index_config)
+        task_def = client.reindex(
+            {
+                "source": {"index": self._index_name},
+                "dest": {"index": next_aliased_index_name},
+            },
+            request_timeout=9999999,
+            wait_for_completion=False,
+        )
+        while True:
+            time.sleep(5)
+            _logger.info("Waiting for task completion %s", task_def)
+            task = client.tasks.get(task_id=task_def["task"], wait_for_completion=False)
+            if task.get("completed"):
+                break
+        if current_aliased_index_name:
+            client.indices.update_aliases(
+                body={
+                    "actions": [
+                        {
+                            "remove": {
+                                "index": current_aliased_index_name,
+                                "alias": self._index_name,
+                            },
+                        },
+                        {
+                            "add": {
+                                "index": next_aliased_index_name,
+                                "alias": self._index_name,
+                            }
+                        },
+                    ]
+                }
+            )
+            client.indices.delete(index=current_aliased_index_name, ignore=[400, 404])
+        else:
+            # This code will only be triggered the first time the reindex is
+            # called on an index created before the use of index aliases.
+            client.indices.delete(index=self._index_name, ignore=[400, 404])
+            client.indices.put_alias(
+                index=next_aliased_index_name, name=self._index_name
+            )


### PR DESCRIPTION
Reindex records according to the current config
This method is useful to allows a rolling update of index configuration.
This process is based on the following steps:
1. create a new index with the current config
2. trigger a reindex into SE from the current index to the new one
3. Update the index alias to point to the new index
4. Drop the old index.